### PR TITLE
add repository ref for nd package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "description": "a documentation viewer for node",
   "version": "1.1.1",
   "preferGlobal": true,
-  "homepage": "https://github.com/russfrank/nd",
+
+  "homepage":            "https://github.com/rf/nd",
+  "bugs":       { "url": "https://github.com/rf/nd/issues" },
+  "repository": { "url": "https://github.com/rf/nd.git", "type": "git" },
+
   "dependencies": {
     "flatiron": "0.1.x",
     "underscore": "1.3.x",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "nd",
+  "author": "Russ Frank <me@russfrank.us>",
+
   "description": "a documentation viewer for node",
   "version": "1.1.1",
   "preferGlobal": true,
@@ -27,7 +30,5 @@
   },
   "bin": {
     "nd": "./bin/nd"
-  },
-  "name": "nd",
-  "author": "Russ Frank <me@russfrank.us"
+  }
 }


### PR DESCRIPTION
Hi. I use `nd` from time to time and keep it in system. When I install any package `npm` shows me a warning that `nd has no repository`. This PR:
- adds field `repository` and `issues` for package
- updates `homepage` field, since you've renamed account on GitHub
- it also moves fields `name` & `author` upper in package, because they're from number of most basic fields
